### PR TITLE
Removed double routing of audio buffer node to destination

### DIFF
--- a/MudExample/Pages/Music.razor
+++ b/MudExample/Pages/Music.razor
@@ -122,7 +122,6 @@
         {
             analyser = await context.CreateAnalyserAsync();
             await currentAudioBufferNode.ConnectAsync(analyser);
-            await analyser.ConnectAsync(destination);
         }
 
         if (currentAudioBufferNode.DisposesJSReference)


### PR DESCRIPTION
Hey, awesome site you have. 😁 I found that the music player was over-gained. After some digging, I found that you had routed the `currentAudioBufferNode` to the `destination` two times. Once direct and once through the `analyser`. This PR removes one of the redundant connections that previously made the accumulative sound reach a higher than 100% gain causing some grainy output.